### PR TITLE
Correct the documents when about fire exception

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -240,7 +240,7 @@ t.Run("Fire Query error", func(t *testing.T) {
 })
 
 t.Run("Fire Execute error", func(t *testing.T) {
-   Catcher.Reset().NewMock().WithQuery("INSERT INTO users (age)").WithQueryException()
+   Catcher.Reset().NewMock().WithQuery("INSERT INTO users (age)").WithExecException()
    err := CreateUsersWithError(DB)
    if err == nil {
 	 t.Fatal("Error not triggered")


### PR DESCRIPTION
When we'd like to fire exception when execute `INSERT` commands, we should call `.WithExecException()` rather than `.WithQueryException()`