### PR TITLE
Deep logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Selvatico/go-mocket
+
+go 1.13
+
+require github.com/sergi/go-diff v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/response.go
+++ b/response.go
@@ -149,11 +149,11 @@ func (fr *FakeResponse) isQueryMatch(query string) bool {
 // IsMatch checks if both query and args matcher's return true and if this is Once mock
 func (fr *FakeResponse) IsMatch(query string, args []driver.NamedValue) bool {
 	fr.mu.Lock()
+	defer fr.mu.Unlock()
+
 	if fr.Once && fr.Triggered {
-		fr.mu.Unlock()
 		return false
 	}
-	fr.mu.Unlock()
 	return fr.isQueryMatch(query) && fr.isArgsMatch(args)
 }
 

--- a/response.go
+++ b/response.go
@@ -160,9 +160,16 @@ func (fr *FakeResponse) IsMatch(query string, args []driver.NamedValue) bool {
 	defer fr.mu.Unlock()
 
 	if fr.Once && fr.Triggered {
+		if Catcher.Logging {
+			fmt.Println("query already triggered")
+		}
 		return false
 	}
-	return fr.isQueryMatch(query) && fr.isArgsMatch(args)
+	argsMatch := fr.isArgsMatch(args)
+	if Catcher.Logging && args != nil {
+		fmt.Printf("query has arguments, did they match? %t\n", argsMatch)
+	}
+	return fr.isQueryMatch(query) && argsMatch
 }
 
 // MarkAsTriggered marks response as executed. For one time catches it will not make this possible to execute anymore

--- a/response.go
+++ b/response.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 const (
@@ -141,6 +143,12 @@ func (fr *FakeResponse) isQueryMatch(query string) bool {
 
 	if fr.Strict == false && strings.Contains(query, fr.Pattern) {
 		return true
+	}
+
+	if Catcher.Logging {
+		comp := diffmatchpatch.New()
+		diffs := comp.DiffMain(query, fr.Pattern, false)
+		fmt.Printf("query do not match with strict = %t:\n%s", fr.Strict, comp.DiffPrettyText(diffs))
 	}
 
 	return false

--- a/response.go
+++ b/response.go
@@ -129,8 +129,8 @@ func (fr *FakeResponse) isArgsMatch(args []driver.NamedValue) bool {
 // isQueryMatch returns true if searched query is matched FakeResponse Pattern
 func (fr *FakeResponse) isQueryMatch(query string) bool {
 	fr.mu.Lock()
-        defer fr.mu.Unlock()
-	
+	defer fr.mu.Unlock()
+
 	if fr.Pattern == "" {
 		return true
 	}


### PR DESCRIPTION
Improves on logging output and failure reporting by, well, adding more `Printf` here and there and explaining with diffs why a query does not match when looking for a fake response.

This PR also migrates the project to go modules as it is using third party dependencies for the first time.