### PR TITLE
Ensure proper replacement

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -110,10 +110,9 @@ func (s *FakeStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (
 	}
 
 	if len(args) > 0 {
-		// Replace all "?" to "%v" and replace them with the values after
+		// Replace all "?" to their proper arg
 		for i := 0; i < len(args); i++ {
-			s.q = strings.Replace(s.q, "?", "%v", 1)
-			s.q = fmt.Sprintf(s.q, args[i].Value)
+			s.q = strings.Replace(s.q, "?", fmt.Sprint(args[i].Value), 1)
 		}
 	}
 


### PR DESCRIPTION
Any `LIKE %%`-statement with another `Where`-statement is currently not properly checked. This PR resolves that.

# Example:

``` golang
query = s.db.Table("accounts").
    Where("accounts.firstName LIKE ?", "%John%").
    Where("accounts.lastName = ?", "Doe")
```

Creates the fake query: 
``` SQL
SELECT * FROM "accounts"  WHERE "accounts"."deleted_at" IS NULL AND ((accounts.firstName LIKE %!J(string=Doe)ohn%!)(MISSING) AND (accounts.lastName = %!v(MISSING)))
```

With this change it generates it properly:
``` SQL
SELECT * FROM "accounts"  WHERE "accounts"."deleted_at" IS NULL AND ((accounts.firstName LIKE %John%) AND (accounts.lastName = Doe))
```